### PR TITLE
Add package infrastructure (paths and unit tests).

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,4 +7,7 @@ setup(
     description='Project objective',
     author='DataKindDC',
     license='MIT',
+    extras_require={
+        "tests": "pytest>=5.4.3",
+    },
 )

--- a/src/tests/test_utils.py
+++ b/src/tests/test_utils.py
@@ -1,0 +1,10 @@
+from src import utils
+
+
+def test_root():
+    assert utils.ROOT.exists()
+    
+    
+def test_data():
+    for path in utils.DATA.values():
+        assert path.exists()

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,0 +1,36 @@
+"""General project utilities.
+
+The following top-level variables make it easier to reference specific
+directories in other scripts and notebooks:
+
+- :data:`src.utils.ROOT`: The project root (usually named ``rcp2/``).
+- :data:`src.utils.DATA`: The project data directory and subdirectories.
+
+.. note::
+   The ``DATA`` variable assumes that you have downloaded and set up the data
+   directory as follows: ::
+
+     Data/
+     ├── 03_Shapefiles
+     │   ├── 2010_Census_shapefiles
+     │   └── SVI2016_US_shapefiles
+     ├── Master Project Data
+     └── processed
+
+"""
+import pathlib
+
+
+# The project root diretory.
+ROOT = pathlib.Path(__file__, "..", "..").resolve()
+
+
+# Paths to project data directories.
+DATA = {
+    "data": ROOT / "Data",
+    "master": ROOT / "Data" / "Master Project Data",
+    "processed": ROOT / "Data" / "processed",
+    "shapefiles": ROOT / "Data" / "03_Shapefiles",
+    "shapefiles-census": ROOT / "Data" / "03_Shapefiles" / "2010_Census_shapefiles",
+    "shapefiles-svi": ROOT / "Data" / "03_Shapefiles" / "SVI2016_US_shapefiles",
+}


### PR DESCRIPTION
While working on #33, I added a module to quickly access specific project directories.

You can use the top level variables in a notebook.

```
>>>from src import utils
>>>utils.ROOT
PosixPath('/my/path/to/rcp2')
```

In the process, I added [pytest](https://docs.pytest.org/en/stable/) as an optional package dependency for `src`. To install the package with the optional dependency, you can run `$ pip install -e .[tests]`. To run the tests, just run `$ pytest`.