### PR TITLE
Add a Makefile with a rule for downloading source data.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+SHELL=/bin/bash
+
+# Activate the project conda environment.
+# Inspired by https://stackoverflow.com/a/55696820.
+CONDA_ACTIVATE=source $$(conda info --base)/etc/profile.d/conda.sh; conda activate rcp2
+
+# Download the project source data.
+download :
+	 $(CONDA_ACTIVATE); python -m src.data.download

--- a/src/data/download.py
+++ b/src/data/download.py
@@ -111,3 +111,8 @@ def download_from_google_drive(url, output_file, pooch):
     
     """
     gdown.download(url, output=output_file)
+
+
+if __name__ == "__main__":
+    # Download the project source data.
+    fetch("nfirs.csv")


### PR DESCRIPTION
You should be able to download the NFIRS data by just running `$ make` in the root directory.

I know enough about make to be dangerous on Linux, but I'm not an expert. I'm eager to hear how well this workflow works on other folks' systems.