### PR TITLE
Add src.data.download module documentation.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,7 +17,7 @@ import sys
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
-# sys.path.insert(0, os.path.abspath('.'))
+sys.path.insert(0, os.path.abspath('..'))
 
 # -- General configuration -----------------------------------------------------
 
@@ -26,7 +26,11 @@ import sys
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = []
+extensions = [
+    "sphinx.ext.autosummary",
+    "sphinx.ext.intersphinx",
+    "sphinx.ext.napoleon",
+]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -242,3 +246,9 @@ texinfo_documents = [
 
 # How to display URL addresses: 'footnote', 'no', or 'inline'.
 # texinfo_show_urls = 'footnote'
+
+# References to outside documentation.
+intersphinx_mapping = {
+    "python": ("https://docs.python.org/3", None),
+    "pooch": ("https://www.fatiando.org/pooch/latest/", None),
+}

--- a/docs/download.rst
+++ b/docs/download.rst
@@ -1,0 +1,22 @@
+The ``download`` Module
+=======================
+
+.. automodule:: src.data.download
+
+
+Top Level Functions
+-------------------
+
+.. autosummary::
+   :toctree: download
+
+   fetch
+
+
+Downloaders
+-----------
+
+.. autosummary::
+  :toctree: download
+
+  download_from_google_drive

--- a/docs/download/src.data.download.download_from_google_drive.rst
+++ b/docs/download/src.data.download.download_from_google_drive.rst
@@ -1,0 +1,6 @@
+src.data.download.download\_from\_google\_drive
+===============================================
+
+.. currentmodule:: src.data.download
+
+.. autofunction:: download_from_google_drive

--- a/docs/download/src.data.download.fetch.rst
+++ b/docs/download/src.data.download.fetch.rst
@@ -1,0 +1,6 @@
+src.data.download.fetch
+=======================
+
+.. currentmodule:: src.data.download
+
+.. autofunction:: fetch

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,6 +13,7 @@ Contents:
 
    getting-started
    commands
+   download
 
 
 

--- a/src/data/download.py
+++ b/src/data/download.py
@@ -8,16 +8,31 @@ downloading files that are already available locally.
 Top level function :func:`src.data.download.fetch` downloads source data files.
 
 Top level variable :data:`src.data.download.SOURCES` is a dict with all the
-source data files that are registered for this project. Add new entries to this
-dict to make them downloadable. New entries should have:
+source data files that are registered for this project. Here's a snippet: ::
+
+    {
+        # National Fire Incident Reporting System (NFIRS) data.
+        "nfirs.csv": {
+            "downloader": "download_from_google_drive",
+            "sha256": "0fcd2c4edae304dbb21c1b0dc6ca9afd17d7d65f21e51cd26571f9d42db7f825",
+            "url": "https://drive.google.com/uc?id=1ENJZwazX7hJ4GwI03DKgX51y-644x-cZ",
+        },
+        ...
+    }
+
+Add more entries to make new files downloadable. New entries should have:
 
 1. A SHA256 hash value to verify download integrity.
 2. A URL for the data source.
 
+You can use :func:`pooch.file_hash` or :mod:`hashlib` to get file hash values.
+
 Optionally, a source can specify a "downloader" function with special
 instructions for downloading a file. The function must be defined somewhere
-and registered in the "downloaders" dict in this module's``fetch`` function.
+and registered in the "downloaders" dict in :func:`src.data.download.fetch`.
 See Pooch documentation on `custom downloaders`_ for details.
+
+Run this module as a script to download project data.
 
 .. _Pooch: https://www.fatiando.org/pooch/latest/index.html
 .. _custom downloaders: https://www.fatiando.org/pooch/latest/usage.html#custom-downloaders
@@ -64,7 +79,7 @@ def fetch(fname):
     function also compares the SHA256 hash of the downloaded file to the one in
     the registry and raises an error if they don't match.
     
-    See :func:`src.data.download.SOURCES` for a list of available files, along
+    See :data:`src.data.download.SOURCES` for a list of available files, along
     with their custom downloaders, SHA256 hashes, and source URLs.
     
     Args:


### PR DESCRIPTION
You can build the docs locally with:

```
$ cd docs/
$ make html
```

The resulting html will be in `docs/_build/html/`.

If this PR and #63 look ok, then we might be able to wrap up issue #61 .